### PR TITLE
X-Real-IP is not needed

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -27,7 +27,6 @@ server {
     proxy_pass         http://django;
     proxy_redirect     off;
     proxy_set_header   Host             $host;
-    proxy_set_header   X-Real-IP        $remote_addr;
     proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
   }
 }

--- a/examples/nginx_ssl.conf
+++ b/examples/nginx_ssl.conf
@@ -18,7 +18,6 @@ server {
     proxy_pass         http://django;
     proxy_redirect     off;
     proxy_set_header   Host             $host;
-    proxy_set_header   X-Real-IP        $remote_addr;
     proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Protocol ssl;
   }


### PR DESCRIPTION
gunicorn and apache-mod-rpaf both use X-Forwarded-For instead
